### PR TITLE
Bugfix: keep a copy of the original authorized_keys

### DIFF
--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -8,6 +8,10 @@
   with_items: github_usernames
   when: github_usernames is defined and github_usernames != []
 
+- name: copy original authorized keys file
+  command: cp /root/.ssh/authorized_keys /tmp/pubkeys
+  # works only in ansible 2.0 copy: src=/root/.ssh/authorized_keys dest=/tmp/pubkeys/authorized_keys remote_src=True force=yes
+
 - name: assemble the authorized keys file
   assemble: dest=/root/.ssh/authorized_keys mode=0600 src=/tmp/pubkeys
   become: true


### PR DESCRIPTION
The ansible assemble command builds a new authorized_keys
file for root.
Before this fix, it used to overwrite the original authorized_keys,
so ansible cannot access the machine anymore, unless using the same
certificate.

Tried to implement with the copy module, but remote_src is only
supported in 2.0, so implemented using the copy command
