### PR TITLE
Some changes from a test deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ End users of the deployment should be able to:
         pip install git+https://github.com/ansible/ansible#egg=ansible
 
 2. Edit the `./hosts` file to lists the FQDN's of the hosts in the jupyterhub_hosts
-   group.
+   group. See `./hosts.example` for an example.
 2. For each host, create a file in `./host_vars` with the name of the host, starting
    from `./host_vars/hostname.example`.
 3. Create a `./security/cookie_secret` file by doing:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ End users of the deployment should be able to:
   - Make sure there is a valid DNS entry for the server.
   - If you not going to use letsencrypt, obtain a trusted SSL certificate and
     key for the server at that FQDN.
+  - Install ansible ≥ 2.0, which has not been released as of January 2016.
+    To get ansible from master:
+
+        pip install git+https://github.com/ansible/ansible#egg=ansible
+
 2. Edit the `./hosts` file to lists the FQDN's of the hosts in the jupyterhub_hosts
    group.
 2. For each host, create a file in `./host_vars` with the name of the host, starting

--- a/host_vars/hostname.example
+++ b/host_vars/hostname.example
@@ -11,7 +11,7 @@
 home_dir: /home
 
 # The users that should be jupyterhub admins
-jupyterhub_admins:
+jupyterhub_admin_users:
   - instructor
 
 # The regular users able to use jupyterhub

--- a/hosts.example
+++ b/hosts.example
@@ -1,0 +1,2 @@
+[jupyterhub_hosts]
+fqdn.goes.here

--- a/roles/common/tasks/hostname.yml
+++ b/roles/common/tasks/hostname.yml
@@ -1,0 +1,5 @@
+---
+
+- name: set the hostname
+  hostname: name="{{inventory_hostname}}"
+  become: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-  
+
+- include: hostname.yml
 - include: ntp.yml
 - include: packages.yml
 - include: mounts.yml

--- a/roles/jupyterhub/tasks/supervisor.yml
+++ b/roles/jupyterhub/tasks/supervisor.yml
@@ -3,3 +3,6 @@
 - name: install supervisor config for jupyterhub
   template: src=jupyterhub.conf.j2 dest=/etc/supervisor/conf.d/jupyterhub.conf owner=root group=root mode=0600 backup=yes
   become: true
+
+- name: start jupyterhub with supervisor
+  supervisorctl: name=jupyterhub state=restarted


### PR DESCRIPTION
address a few things I ran into during a test deployment today

Server: Ubuntu 14.04, freshly provisioned
Client: OS X, Ansible 2.1-dev (current stable: 1.9 is too old)


- mention that this requires unreleased ansible 2
- set the hostname of the server so that ansible_fqdn has the right value
- add hosts.example, showing the format it should have
- jupyterhub_admin_users typo in variable name (mismatch between variable used in template and defined in example config)
- start JupyterHub with supervisor after adding the config

Other than those minor tweaks, it worked pretty well. I did run out of memory on a 1GB VM trying to build scipy, and had to start over with a bigger allocation.